### PR TITLE
Tricia/edit tickets

### DIFF
--- a/cypress/e2e/board.cy.ts
+++ b/cypress/e2e/board.cy.ts
@@ -76,7 +76,7 @@ describe('Test landing page', () => {
     cy.get('.button.rose-color').click().get('.delete').click().get('.columns')
   })
 
-  it.only('Should have the ability to move a ticket from one swimlane to another', () => {
+  it('Should have the ability to move a ticket from one swimlane to another', () => {
     cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'update_status_data.json' })
 
     cy.get('.columns >:nth-child(1)').find('.ticket').trigger('dragstart').trigger('dragleave')
@@ -84,7 +84,7 @@ describe('Test landing page', () => {
     cy.get('.columns >:nth-child(2)').find('.ticket').should('contain', 'Unable to log in to account')
   })
 
-  it.only('Should have the ability to edit a ticket, update the status by dragging and drop, and have all their informaiton persist', () => {
+  it('Should have the ability to edit a ticket, update the status by dragging and drop, and have all the new informaiton persist', () => {
     cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'drag_drop_one.json' })
 
     cy.get('.columns >:nth-child(1)')
@@ -103,6 +103,7 @@ describe('Test landing page', () => {
       .click()
 
     cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'drag_drop_two.json' })
+
     cy.get('.columns >:nth-child(1)').find('.ticket').trigger('dragstart').trigger('dragleave')
     cy.get('.columns >:nth-child(4)').trigger('dragenter').trigger('dragover').trigger('drop').trigger('dragend')
     cy.get('.columns >:nth-child(4)').find('.ticket').eq(1).should('contain', 'Fix drag and drop bug').click()

--- a/cypress/e2e/board.cy.ts
+++ b/cypress/e2e/board.cy.ts
@@ -76,11 +76,39 @@ describe('Test landing page', () => {
     cy.get('.button.rose-color').click().get('.delete').click().get('.columns')
   })
 
-  it('Should have the ability to move a ticket from one swimlane to another', () => {
+  it.only('Should have the ability to move a ticket from one swimlane to another', () => {
     cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'update_status_data.json' })
 
     cy.get('.columns >:nth-child(1)').find('.ticket').trigger('dragstart').trigger('dragleave')
     cy.get('.columns >:nth-child(2)').trigger('dragenter').trigger('dragover').trigger('drop').trigger('dragend')
     cy.get('.columns >:nth-child(2)').find('.ticket').should('contain', 'Unable to log in to account')
+  })
+
+  it.only('Should have the ability to edit a ticket, update the status by dragging and drop, and have all their informaiton persist', () => {
+    cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'drag_drop_one.json' })
+
+    cy.get('.columns >:nth-child(1)')
+      .find('.ticket')
+      .should('contain', 'Unable to log in to account')
+      .find('button')
+      .click()
+      .get('input[name="title"]')
+      .clear()
+      .type('Fix drag and drop bug')
+
+    cy.get('input[name="description"]')
+      .clear()
+      .type('Title and description are not persisting if you edit and then drag and drop.')
+      .get('.button.is-success')
+      .click()
+
+    cy.intercept('PUT', 'http://localhost:8000/tickets/1', { fixture: 'drag_drop_two.json' })
+    cy.get('.columns >:nth-child(1)').find('.ticket').trigger('dragstart').trigger('dragleave')
+    cy.get('.columns >:nth-child(4)').trigger('dragenter').trigger('dragover').trigger('drop').trigger('dragend')
+    cy.get('.columns >:nth-child(4)').find('.ticket').eq(1).should('contain', 'Fix drag and drop bug').click()
+    cy.get('.message-body').contains('Fix drag and drop bug')
+    cy.get('.message-body').contains('Title and description are not persisting if you edit and then drag and drop.')
+    cy.get('.delete').click()
+    cy.get('img')
   })
 })

--- a/cypress/fixtures/drag_drop_one.json
+++ b/cypress/fixtures/drag_drop_one.json
@@ -1,0 +1,6 @@
+{
+  "id": "1",
+  "title": "Fix drag and drop bug",
+  "description": "Title and description are not persisting if you edit and then drag and drop.",
+  "status": "backlog"
+}

--- a/cypress/fixtures/drag_drop_two.json
+++ b/cypress/fixtures/drag_drop_two.json
@@ -1,0 +1,6 @@
+{
+  "id": "1",
+  "title": "Fix drag and drop bug",
+  "description": "Title and description are not persisting if you edit and then drag and drop.",
+  "status": "done"
+}

--- a/src/components/Ticket.tsx
+++ b/src/components/Ticket.tsx
@@ -23,13 +23,12 @@ export default function Ticket({ id, title, description, status }: TicketProps) 
       if (item && dropResult) {
         const name = dropResult.name
         dispatch(updateTicket({ id, title, description, status: name, prevStatus: status }))
-        console.log(dropResult)
       }
     },
     collect: (monitor) => ({
       isDragging: !!monitor.isDragging(),
     }),
-  }))
+  }), [title, description])
 
   useEffect(() => {
     if (error !== null) {


### PR DESCRIPTION
What does this PR do?
---

- [x] Add `title` and `description` to the `useDrag` hook's dependency array, so when the title and description update from the edit ticket form, drag and drop wouldn't override it with the previous title and description, it had cached in its hook. 

- [x] Add `Cypress tests` for when a user `edits a ticket` and then `drags and drops to a new swimlane` without page loads in-between.